### PR TITLE
Remove logo and skywalking dev mail list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SkyWalking PHP
 
-<img src="https://skywalkingtest.github.io/page-resources/3.0/skywalking.png" alt="Sky Walking logo" height="90px" align="right" />
-
 SkyWalking PHP is the PHP instrumentation agent, which is compatible with [Apache SkyWalking(Incubating) APM](https://github.com/apache/incubator-skywalking) backend and others compatible agents/SDKs
 
 ## Documents
@@ -12,7 +10,6 @@ SkyWalking PHP is the PHP instrumentation agent, which is compatible with [Apach
 
 # Contact Us
 * Submit an issue
-* Mail list: dev@skywalking.apache.org
 * [Gitter](https://gitter.im/openskywalking/Lobby)
 * QQ Group: 392443393
 


### PR DESCRIPTION
@heyanlong Since you have not decided the solution, I just try to remove the SkyWalking logo first.
I hope we could deal with the trademark and branding issue as soon as possible.